### PR TITLE
[ FEATURE ] 관심사 구독자 수 변경 기능 추가

### DIFF
--- a/src/main/java/team03/monew/entity/interest/Interest.java
+++ b/src/main/java/team03/monew/entity/interest/Interest.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -27,6 +28,9 @@ public class Interest extends BaseEntity {
 
   @Column(nullable = false)
   private long subscriberCount; // 구독자 수
+  
+  @Version
+  private int version;  // 낙관적 락 버전
 
   // 부모 객체 저장/수정/삭제 시 자식 객체도 저장/수정/삭제, 고아 객체 삭제
   @OneToMany(mappedBy = "interest", orphanRemoval = true, cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE})

--- a/src/main/java/team03/monew/service/interest/InterestService.java
+++ b/src/main/java/team03/monew/service/interest/InterestService.java
@@ -22,11 +22,8 @@ public interface InterestService {
   // 관심사 검색
   CursorPageResponse<InterestDto> find(InterestFindRequest request, UUID userId);
 
-  // 관심사 구독자 수 증가
-  void increaseSubscriberCount(Interest interest);
-
-  // 관심사 구독자 수 감소
-  void decreaseSubscriberCount(Interest interest);
+  // 관심사 구독자 수 변경
+  void updateSubscriberCount(Interest interest, boolean increase);
 
   // 관심사 엔티티 반환
   Interest getInterestEntityById(UUID interestId);

--- a/src/main/java/team03/monew/service/interest/InterestService.java
+++ b/src/main/java/team03/monew/service/interest/InterestService.java
@@ -13,7 +13,7 @@ public interface InterestService {
   // 관심사 등록
   InterestDto create(InterestRegisterRequest request);
 
-  // 관심사 수정
+  // 관심사 키워드 수정
   InterestDto update(UUID interestId, InterestUpdateRequest request, UUID userId);
 
   // 관심사 삭제

--- a/src/main/java/team03/monew/service/interest/impl/InterestServiceImpl.java
+++ b/src/main/java/team03/monew/service/interest/impl/InterestServiceImpl.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.text.similarity.LevenshteinDistance;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
@@ -23,6 +24,7 @@ import team03.monew.util.exception.interest.InterestAlreadyExistException;
 import team03.monew.util.exception.interest.InterestNotFoundException;
 import team03.monew.util.exception.interest.OrderByValueException;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional    // 모든 public 메서드에 적용됨
@@ -34,8 +36,11 @@ public class InterestServiceImpl implements InterestService {
   @Lazy   // 순환참조 해결을 위한 지연 로딩
   private final SubscriptionService subscriptionService;
 
+  // 관심사 등록
   @Override
   public InterestDto create(InterestRegisterRequest request) {
+
+    log.debug("관심사 등록 시작: request={}", request);
 
     // request 쪼개기
     String name = request.name();
@@ -61,56 +66,87 @@ public class InterestServiceImpl implements InterestService {
     // 레포지토리 저장
     interestRepository.save(interest);
 
-    // 결과물 반환
-    return interestMapper.toDto(interest, false);
+    // dto로 변환
+    InterestDto interestDto = interestMapper.toDto(interest, false);
+
+    log.info("관심사 등록 완료: interestId={}, interestName={}", interestDto.id(), interestDto.name());
+
+    return interestDto;
   }
 
+  // 관심사 키워드 수정
   @Override
   public InterestDto update(UUID interestId, InterestUpdateRequest request, UUID userId) {
 
+    log.debug("관심사 키워드 수정 시작: interestId={}, request={}, userId={}", interestId, request, userId);
+
+    // 해당 관심사 repository에서 찾기, 예외처리 - 관심사 없는 경우
     Interest interest = interestRepository.findById(interestId)
         .orElseThrow(() -> InterestNotFoundException.withInterestId(interestId));
-    List<String> keywords = request.keywords();
 
+    // 키워드 수정
+    List<String> keywords = request.keywords();
     interest.updateKeywords(keywords);
 
-    return interestMapper.toDto(
+    // dto로 변환
+    InterestDto interestDto = interestMapper.toDto(
         interest,
         subscriptionService.existByUserIdAndInterestId(userId, interestId)
     );
+
+    log.info("관심사 키워드 수정 완료: interestId={}, keywords={}", interestId, interestDto.keywords());
+
+    return interestDto;
   }
 
+  // 관심사 삭제
   @Override
   public void delete(UUID interestId) {
 
+    log.debug("관심사 삭제 시작: interestId={}", interestId);
+
+    // 예외처리 - 해당 관심사가 존재하는지 확인
     Interest interest = interestRepository.findById(interestId)
         .orElseThrow(() -> InterestNotFoundException.withInterestId(interestId));
 
+    // 삭제
     interestRepository.delete(interest);
+
+    log.info("관심사 삭제 완료: interestId={}", interestId);
   }
 
+  // 관심사 목록 조회
   @Override
   @Transactional(readOnly = true)
   public CursorPageResponse<InterestDto> find(InterestFindRequest request, UUID userId) {
 
+    log.debug("관심사 목록 조회 시작: request={}, userId={}", request, userId);
+
+    // 조건에 부합하는 관심사 리스트 가져오기
     List<Interest> interestList = interestRepository.findInterest(request);
+
+    // dto로 넘길 정보 변수 선언
     String nextCursor = null;
     Instant nextAfter = null;
     boolean hasNext = false;
 
-    if (interestList.size() > request.limit()) {  // 다음 페이지가 있는 경우
+    // 다음 페이지가 있는 경우
+    if (interestList.size() > request.limit()) {
       interestList.remove(request.limit());  // 다음 페이지 확인용 마지막 요소 삭제
       Interest lastInterest = interestList.get(request.limit() - 1); // 해당 페이지 마지막 요소
       nextCursor = setNextCursor(lastInterest, request.orderBy());
       nextAfter = lastInterest.getCreatedAt();
+      hasNext = true;
     }
 
+    // dto 변환
     List<InterestDto> content = interestList.stream()
         .map(interest -> interestMapper.toDto(interest,
             subscriptionService.existByUserIdAndInterestId(userId, interest.getId())))
         .toList();
 
-    return new CursorPageResponse<>(
+    // 커서 페이지네이션 응답용 dto 세팅
+    CursorPageResponse<InterestDto> cursorPageResponse = new CursorPageResponse<>(
         content,
         nextCursor,
         nextAfter,
@@ -118,23 +154,52 @@ public class InterestServiceImpl implements InterestService {
         interestRepository.totalCountInterest(request),
         hasNext
     );
+
+    log.info("관심사 목록 조회 완료: userId={}, 반환 개수={}, hasNext={}, nextCursor={}, totalElements={}",
+        userId, content.size(), hasNext, nextCursor, cursorPageResponse.totalElements());
+
+    return cursorPageResponse;
   }
 
+  // 구독자 수 증가
   @Override
   public void increaseSubscriberCount(Interest interest) {
+
+    log.debug("구독자 수 증가 시작: interestId={}, subscriberCount={}", interest.getId(),
+        interest.getSubscriberCount());
+
     interest.increaseSubscribers();
+
+    log.info("구독자 수 증가 완료: interestId={}, subscriberCount={}", interest.getId(),
+        interest.getSubscriberCount());
   }
 
+  // 구독자 수 감소
   @Override
   public void decreaseSubscriberCount(Interest interest) {
+
+    log.debug("구독자 수 감소 시작: interestId={}, subscriberCount={}", interest.getId(),
+        interest.getSubscriberCount());
+
     interest.decreaseSubscribers();
+
+    log.info("구독자 수 감소 완료: interestId={}, subscriberCount={}", interest.getId(),
+        interest.getSubscriberCount());
   }
 
+  // 관심사 엔티티 반환
   @Override
   @Transactional(readOnly = true)
   public Interest getInterestEntityById(UUID interestId) {
-    return interestRepository.findById(interestId)
+
+    log.debug("관심사 엔티티 반환 시작: interestId={}", interestId);
+
+    Interest interest = interestRepository.findById(interestId)
         .orElseThrow(() -> InterestNotFoundException.withInterestId(interestId));
+
+    log.info("관심사 엔티티 반환 완료: interestId={}, interestName={}", interest.getId(), interest.getName());
+
+    return interest;
   }
 
 

--- a/src/main/java/team03/monew/service/interest/impl/SubscriptionServiceImpl.java
+++ b/src/main/java/team03/monew/service/interest/impl/SubscriptionServiceImpl.java
@@ -2,7 +2,7 @@ package team03.monew.service.interest.impl;
 
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.annotation.Lazy;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team03.monew.dto.interest.SubscriptionDto;
@@ -18,6 +18,7 @@ import team03.monew.service.user.UserService;
 import team03.monew.util.exception.subscription.SubscriptionAlreadyExistException;
 import team03.monew.util.exception.subscription.SubscriptionNotFoundException;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -29,8 +30,11 @@ public class SubscriptionServiceImpl implements SubscriptionService {
   private final UserService userService;
   private final InterestService interestService;
 
+  // 구독
   @Override
   public SubscriptionDto create(UUID userId, UUID interestId) {
+
+    log.debug("[create] 구독 시작: userId={}, interestId={}", userId, interestId);
 
     // 필요한 user, interest 세팅
     User user = userService.findUserById(userId);
@@ -48,22 +52,30 @@ public class SubscriptionServiceImpl implements SubscriptionService {
     // interest 구독자 수 증가
     interestService.increaseSubscriberCount(interest);
 
-    // subscriptionDto로 변환 및 반환
-    return subscriptionMapper
+    // dto 변환
+    SubscriptionDto subscriptionDto = subscriptionMapper
         .toDto(
             subscription,
             interestMapper.toDto(interest, true)
         );
+
+    log.info("[create] 구독 완료: subscriptionId={}, subscribed_at={}", subscription.getId(), subscription.getCreatedAt());
+
+    return subscriptionDto;
   }
 
+  // 구독 취소
   @Override
   public void delete(UUID userId, UUID interestId) {
+
+    log.debug("[delete] 구독 취소 시작: userId={}, interestId={}", userId, interestId);
 
     // 필요한 user, interest 세팅
     Interest interest = interestService.getInterestEntityById(interestId);
 
     // subscription 가져오기, 예외처리 - 해당 구독 정보 없는 경우
-    Subscription subscription = subscriptionRepository.findByUser_IdAndInterest_Id(userId, interestId)
+    Subscription subscription = subscriptionRepository.findByUser_IdAndInterest_Id(userId,
+            interestId)
         .orElseThrow(
             () -> SubscriptionNotFoundException.withUserIdAndInterestId(userId, interestId));
 
@@ -72,12 +84,18 @@ public class SubscriptionServiceImpl implements SubscriptionService {
 
     // 구독자 수 감소
     interestService.decreaseSubscriberCount(interest);
+
+    log.info("[delete] 구독 취소 완료: subscriptionId={}, userId={}, interestId={}", subscription.getId(), userId, interestId);
   }
 
+  // 구독 여부 확인
   @Override
   public boolean existByUserIdAndInterestId(UUID userId, UUID interestId) {
 
-    // 구독 여부 반환
-    return subscriptionRepository.existsByUser_IdAndInterest_Id(userId, interestId);
+    boolean isExisted = subscriptionRepository.existsByUser_IdAndInterest_Id(userId, interestId);
+
+    log.info("[existByUserIdAndInterestId] 구독 여부 확인: userId={}, interestId={}, isSubscribed={}", userId, interestId, isExisted);
+
+    return isExisted;
   }
 }

--- a/src/main/java/team03/monew/service/interest/impl/SubscriptionServiceImpl.java
+++ b/src/main/java/team03/monew/service/interest/impl/SubscriptionServiceImpl.java
@@ -50,7 +50,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
     subscriptionRepository.save(subscription);
 
     // interest 구독자 수 증가
-    interestService.increaseSubscriberCount(interest);
+    interestService.updateSubscriberCount(interest, true);
 
     // dto 변환
     SubscriptionDto subscriptionDto = subscriptionMapper
@@ -83,7 +83,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
     subscriptionRepository.delete(subscription);
 
     // 구독자 수 감소
-    interestService.decreaseSubscriberCount(interest);
+    interestService.updateSubscriberCount(interest, false);
 
     log.info("[delete] 구독 취소 완료: subscriptionId={}, userId={}, interestId={}", subscription.getId(), userId, interestId);
   }

--- a/src/main/java/team03/monew/service/interest/impl/SubscriptionServiceImpl.java
+++ b/src/main/java/team03/monew/service/interest/impl/SubscriptionServiceImpl.java
@@ -2,6 +2,7 @@ package team03.monew.service.interest.impl;
 
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team03.monew.dto.interest.SubscriptionDto;
@@ -25,8 +26,8 @@ public class SubscriptionServiceImpl implements SubscriptionService {
   private final SubscriptionRepository subscriptionRepository;
   private final SubscriptionMapper subscriptionMapper;
   private final InterestMapper interestMapper;
-  private final InterestService interestService;
   private final UserService userService;
+  private final InterestService interestService;
 
   @Override
   public SubscriptionDto create(UUID userId, UUID interestId) {
@@ -73,7 +74,6 @@ public class SubscriptionServiceImpl implements SubscriptionService {
     interestService.decreaseSubscriberCount(interest);
   }
 
-  // TODO: 순환참조 문제 없이 boolean값 InterestService에 넘길 방법 찾기
   @Override
   public boolean existByUserIdAndInterestId(UUID userId, UUID interestId) {
 

--- a/src/test/java/team03/monew/service/interest/SubscriptionServiceTest.java
+++ b/src/test/java/team03/monew/service/interest/SubscriptionServiceTest.java
@@ -1,7 +1,9 @@
 package team03.monew.service.interest;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -152,5 +154,40 @@ public class SubscriptionServiceTest {
     }
   }
   
-  // TODO: 구독 여부 확인 테스트 코드 작성
+  @Nested
+  @DisplayName("existByUserIdAndInterestId() - 구독 여부 확인 테스트")
+  class ExistByUserIdAndInterestIdTest {
+
+    @Test
+    @DisplayName("[success] 구독 중일 경우 true 반환")
+    void successReturnTrueTest() {
+      // given
+      UUID userId = UUID.randomUUID();
+      UUID interestId = UUID.randomUUID();
+      given(subscriptionRepository.existsByUser_IdAndInterest_Id(userId, interestId)).willReturn(true);
+
+      // when
+      boolean result = subscriptionService.existByUserIdAndInterestId(userId, interestId);
+
+      // then
+      assertTrue(result);
+      verify(subscriptionRepository).existsByUser_IdAndInterest_Id(userId, interestId);
+    }
+
+    @Test
+    @DisplayName("[success] 구독하지 않을 경우 false 반환")
+    void successReturnFalseTest() {
+      // given
+      UUID userId = UUID.randomUUID();
+      UUID interestId = UUID.randomUUID();
+      given(subscriptionRepository.existsByUser_IdAndInterest_Id(userId, interestId)).willReturn(false);
+
+      // when
+      boolean result = subscriptionService.existByUserIdAndInterestId(userId, interestId);
+
+      // then
+      assertFalse(result);
+      verify(subscriptionRepository).existsByUser_IdAndInterest_Id(userId, interestId);
+    }
+  }
 }

--- a/src/test/java/team03/monew/service/interest/SubscriptionServiceTest.java
+++ b/src/test/java/team03/monew/service/interest/SubscriptionServiceTest.java
@@ -79,7 +79,7 @@ public class SubscriptionServiceTest {
 
       // then
       verify(subscriptionRepository).save(any(Subscription.class));
-      verify(interestService).increaseSubscriberCount(interest);
+      verify(interestService).updateSubscriberCount(interest, true);
       assertThat(result).isEqualTo(subscriptionDto);
     }
 
@@ -129,7 +129,7 @@ public class SubscriptionServiceTest {
 
       // then
       verify(subscriptionRepository).delete(any(Subscription.class));
-      verify(interestService).decreaseSubscriberCount(any(Interest.class));
+      verify(interestService).updateSubscriberCount(interest, false);
     }
 
     @Test


### PR DESCRIPTION
## 구현 내용
- 구독/구독 취소 시 관심사의 구독자 수 변경되도록 구현
- 낙관적 락을 통해 구독자 수 동시성 문제 예방
- 로그 추가

### 주요 변경사항


## 테스트 완료 사항
- [ ] 단위 테스트
- [ ] 통합 테스트
- [ ] API 테스트 (Swagger/Postman 등)
- [ ] 기타 테스트


## 체크리스트
- [x] 코딩, 커밋 컨벤션 준수
- [x] 브랜치 위치 확인
- [x] label 지정
- [ ] 모든 테스트 통과
- [x] API 명세 준수
- [x] 불필요한 로그, 주석, 미사용 코드 제거
- [x] 리뷰 요청



## 관련 이슈
Close #44 

## 추가 코멘트 (선택)
- 현재 알 수 없는 문제로 빌드 시 q클래스가 만들어지지 않아 테스트를 제대로 실행하지 못하였습니다.
- 트래픽이 적을거라 예상되어 낙관적 락을 통해 동시성 제어를 해보았습니다. 혹시 다른 의견 있다면 말씀 부탁드립니다!
