### PR TITLE
[ FEATURE ] 관심사 관리 컨트롤러 수정 

### DIFF
--- a/src/main/java/team03/monew/controller/interest/InterestController.java
+++ b/src/main/java/team03/monew/controller/interest/InterestController.java
@@ -1,5 +1,6 @@
 package team03.monew.controller.interest;
 
+import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +23,7 @@ import team03.monew.dto.interest.InterestFindRequest;
 import team03.monew.dto.interest.InterestRegisterRequest;
 import team03.monew.dto.interest.InterestUpdateRequest;
 import team03.monew.service.interest.InterestService;
+import team03.monew.util.interest.AdminValidator;
 
 @Slf4j
 @RestController
@@ -33,9 +35,13 @@ public class InterestController {
 
   // 관심사 등록
   @PostMapping
-  public ResponseEntity<InterestDto> create(@RequestBody @Valid InterestRegisterRequest request) {
+  public ResponseEntity<InterestDto> create(
+      @RequestBody @Valid InterestRegisterRequest request,
+      HttpSession session) {
 
     log.info("관심사 등록 요청: {}", request);
+
+    AdminValidator.adminValidator(session);
 
     InterestDto interestDto = interestService.create(request);
 
@@ -49,10 +55,13 @@ public class InterestController {
   public ResponseEntity<InterestDto> update(
       @PathVariable UUID interestId,
       @RequestBody @Valid InterestUpdateRequest request,
-      @RequestHeader(value = "Monew-Request-User-ID") UUID userId
+      @RequestHeader(value = "Monew-Request-User-ID") UUID userId,
+      HttpSession session
   ) {
 
     log.info("관심사 정보 수정 요청: interestId={}", interestId);
+
+    AdminValidator.adminValidator(session);
 
     InterestDto interestDto = interestService.update(interestId, request, userId);
 
@@ -63,9 +72,13 @@ public class InterestController {
 
   // 관심사 물리 삭제
   @DeleteMapping("/{interestId}")
-  public ResponseEntity<Void> delete(@PathVariable UUID interestId) {
+  public ResponseEntity<Void> delete(
+      @PathVariable UUID interestId,
+      HttpSession session) {
 
     log.info("관심사 물리 삭제 요청: interestId={}", interestId);
+
+    AdminValidator.adminValidator(session);
 
     interestService.delete(interestId);
 

--- a/src/main/java/team03/monew/util/exception/ErrorCode.java
+++ b/src/main/java/team03/monew/util/exception/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
   SIMILAR_INTEREST_EXISTS("INTEREST_002", "작성하신 관심사가 이미 존재하는 관심사와 유사합니다.", HttpStatus.CONFLICT),
   INVALID_KEYWORD_COUNT("INTEREST_003", "키워드는 최소 1개 이상이어야 합니다.", HttpStatus.BAD_REQUEST),
   INVALID_ORDER_BY("INTEREST_004", "정렬은 '이름' 또는 '구독자 수' 기준으로만 가능합니다.", HttpStatus.BAD_REQUEST),
+  UNAUTHORIZED("INTEREST_005", "관리자만 접근할 수 있습니다.", HttpStatus.FORBIDDEN),
   
   // subscription 에러 코드
   SUBSCRIPTION_NOT_FOUND("SUBSCRIPTION_001", "해당 구독 정보가 존재하지 않습니다.", HttpStatus.NOT_FOUND),

--- a/src/main/java/team03/monew/util/exception/interest/UnauthorizedException.java
+++ b/src/main/java/team03/monew/util/exception/interest/UnauthorizedException.java
@@ -1,0 +1,16 @@
+package team03.monew.util.exception.interest;
+
+import team03.monew.util.exception.ErrorCode;
+
+public class UnauthorizedException extends InterestException{
+
+  public UnauthorizedException() {
+    super(ErrorCode.UNAUTHORIZED);
+  }
+
+  public static UnauthorizedException withRole(String role) {
+    UnauthorizedException exception = new UnauthorizedException();
+    exception.addDetail("role", role);
+    return exception;
+  }
+}

--- a/src/main/java/team03/monew/util/interest/AdminValidator.java
+++ b/src/main/java/team03/monew/util/interest/AdminValidator.java
@@ -1,0 +1,19 @@
+package team03.monew.util.interest;
+
+import jakarta.servlet.http.HttpSession;
+import team03.monew.util.exception.interest.UnauthorizedException;
+
+public class AdminValidator {
+
+  private AdminValidator() {
+  }
+
+  // 권한이 관리자가 맞는지 체크
+  public static void adminValidator(HttpSession session) {
+
+    String role = (String) session.getAttribute("role");
+    if (role == null || !role.equals("admin")) {
+      throw UnauthorizedException.withRole(role);
+    }
+  }
+}

--- a/src/test/java/team03/monew/controller/interest/SubscriptionControllerTest.java
+++ b/src/test/java/team03/monew/controller/interest/SubscriptionControllerTest.java
@@ -18,7 +18,6 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import team03.monew.dto.interest.SubscriptionDto;
 import team03.monew.service.interest.SubscriptionService;
-import team03.monew.service.user.UserService;
 
 @WebMvcTest(SubscriptionController.class)
 public class SubscriptionControllerTest {
@@ -31,9 +30,6 @@ public class SubscriptionControllerTest {
 
   @MockitoBean
   private SubscriptionService subscriptionService;
-
-  @MockitoBean
-  private UserService userService;  // UserInterceptor에서 필요함
 
   @Test
   @DisplayName("create() - 관심사 구독 테스트")


### PR DESCRIPTION
## 구현 내용

### 주요 변경사항
- 관심사 등록/수정/삭제를 관리자만 할 수 있도록 변경

## 테스트 완료 사항
- [x] 단위 테스트
- [ ] 통합 테스트
- [ ] API 테스트 (Swagger/Postman 등)
- [ ] 기타 테스트


## 체크리스트
- [x] 코딩, 커밋 컨벤션 준수
- [x] 브랜치 위치 확인
- [x] label 지정
- [ ] 모든 테스트 통과
- [x] API 명세 준수
- [x] 불필요한 로그, 주석, 미사용 코드 제거
- [x] 리뷰 요청



## 관련 이슈
Close #62 

## 추가 코멘트 (선택)
- 현재 UNAUTHORIZED 에러코드를 interest 카테고리에 넣어야 할지, user 카테고리에 넣어야 할지, Auth 카테고리에 넣어야할지 고민되어 일단 interest에 넣어놓은 상태입니다. 의견 부탁드립니다!